### PR TITLE
Hook performance

### DIFF
--- a/debugger/breakpoint.ts
+++ b/debugger/breakpoint.ts
@@ -40,7 +40,7 @@ export namespace Breakpoint {
     }
 
     export function getLines(): {[key: number]: boolean} {
-        const ret: {[key: number]: boolean} = {};
+        const lines: {[key: number]: boolean} = {};
         for (const [_, breakpoint] of ipairs(current)) {
             ret[breakpoint.line] = true;
         }
@@ -65,4 +65,3 @@ export namespace Breakpoint {
         current = [];
     }
 }
-

--- a/debugger/breakpoint.ts
+++ b/debugger/breakpoint.ts
@@ -39,6 +39,14 @@ export namespace Breakpoint {
         return current;
     }
 
+    export function getLines(): {[key: number]: boolean} {
+        const ret: {[key: number]: boolean} = {};
+        for (const [_, breakpoint] of ipairs(current)) {
+            ret[breakpoint.line] = true;
+        }
+        return ret;
+    }
+
     export function add(file: string, line: number, condition?: string) {
         table.insert(current, {file: Path.format(file), line, enabled: true, condition});
     }

--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -583,7 +583,7 @@ export namespace Debugger {
 
     const topFrameStackOffset = 2;
 
-    function isIgnoreStepBreak(topFrame: debug.FunctionInfo): boolean {
+    function ignoreStepBreak(topFrame: debug.FunctionInfo): boolean {
         //Ignore debugger code
         if (!topFrame || !topFrame.source || topFrame.source.sub(-debuggerName.length) === debuggerName) {
             return true;

--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -597,7 +597,7 @@ export namespace Debugger {
         return false;
     }
 
-    function checkAllBreakPoint(stackOffset: number, line: number) {
+    function checkAllBreakPoints(stackOffset: number, line: number) {
         if (!breakPointLines[line]) {
             return;
         }

--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -794,7 +794,7 @@ export namespace Debugger {
 
         for (const [thread] of pairs(threadIds)) {
             if (isThread(thread) && coroutine.status(thread) !== "dead") {
-                if (!!hook) {
+                if (hook !== undefined) {
                     debug.sethook(thread, hook, "l");
                 } else {
                     debug.sethook(thread);

--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -786,7 +786,7 @@ export namespace Debugger {
     }
 
     function setHook(hook?: debug.Hook) {
-        if (!!hook) {
+        if (hook !== undefined) {
             debug.sethook(hook, "l");
         } else {
             debug.sethook();

--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -701,7 +701,7 @@ export namespace Debugger {
 
         const [hook] = debug.gethook();
         if (hook === runHook || hook === stepHook) {
-            debug.sethook(thread, runHook, "l");
+            debug.sethook(thread, hook, "l");
         }
 
         return threadId;

--- a/debugger/tsconfig.json
+++ b/debugger/tsconfig.json
@@ -17,7 +17,6 @@
         "luaTarget": "5.1",
         "noImplicitSelf": true,
         "noHeader": true,
-        "noHoisting": true,
         "luaBundle": "lldebugger.lua",
         "luaBundleEntry": "lldebugger.ts"
     }


### PR DESCRIPTION
Improve run-time performance.

Switch to a lightweight debughook at runtime. At the beginning of the hook, check the breakpoint and current line to reduce the if statement being executed.
