### PR TITLE
Pull support for breakpoints update 

### DIFF
--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -87,7 +87,12 @@ export namespace Debugger {
         }
         pullFile = file as LuaFile;
         pullFile.setvbuf("no");
-        lastPullSeek = pullFile.seek("end")[0] as number;
+        const [fileSize, errorSeek] = pullFile.seek("end");
+        if (!fileSize) {
+            luaError(`Failed to read pull file "${pullFilePath}": ${errorSeek}\n`);
+        } else {
+            lastPullSeek = fileSize;
+        }
     } else {
         pullFile = null;
     }
@@ -868,7 +873,7 @@ export namespace Debugger {
         if (isDebugHookDisabled) {
             return;
         }
-        
+
         //Stepping
         if (breakAtDepth >= 0) {
             const activeThread = getActiveThread();
@@ -1167,7 +1172,7 @@ export namespace Debugger {
         isDebugHookDisabled = breakAtDepth < 0 && Breakpoint.getCount() === 0;
         // Do not disable debugging in luajit environment with pull breakpoints support enabled
         // or functions will be jitted and will lose debug info of lines and files
-        if (isDebugHookDisabled && (_G['jit'] === null || pullFile == null)) {
+        if (isDebugHookDisabled && (_G["jit"] === null || pullFile === null)) {
             debug.sethook();
 
             for (const [thread] of pairs(threadIds)) {

--- a/debugger/debugger.ts
+++ b/debugger/debugger.ts
@@ -491,6 +491,7 @@ export namespace Debugger {
     let breakAtDepth = -1;
     let breakInThread: Thread | undefined;
     let updateHook: { (): void };
+    let isDebugHookDisabled = true;
     let ignorePatterns: string[] | undefined;
     let inDebugBreak = false;
 
@@ -864,6 +865,10 @@ export namespace Debugger {
     const skipUnmappedLines = (os.getenv(stepUnmappedLinesEnv) !== "1");
 
     function debugHook(event: "call" | "return" | "tail return" | "count" | "line", line?: number) {
+        if (isDebugHookDisabled) {
+            return;
+        }
+        
         //Stepping
         if (breakAtDepth >= 0) {
             const activeThread = getActiveThread();
@@ -1159,7 +1164,10 @@ export namespace Debugger {
     }
 
     updateHook = function() {
-        if (breakAtDepth < 0 && Breakpoint.getCount() === 0) {
+        isDebugHookDisabled = breakAtDepth < 0 && Breakpoint.getCount() === 0;
+        // Do not disable debugging in luajit environment with pull breakpoints support enabled
+        // or functions will be jitted and will lose debug info of lines and files
+        if (isDebugHookDisabled && (_G['jit'] === null || pullFile == null)) {
             debug.sethook();
 
             for (const [thread] of pairs(threadIds)) {
@@ -1189,6 +1197,7 @@ export namespace Debugger {
         coroutine.wrap = luaCoroutineWrap;
         coroutine.resume = luaCoroutineResume;
 
+        isDebugHookDisabled = true;
         debug.sethook();
 
         for (const [thread] of pairs(threadIds)) {

--- a/debugger/lldebugger.ts
+++ b/debugger/lldebugger.ts
@@ -55,6 +55,11 @@ export function stop(): void {
     Debugger.clearHook();
 }
 
+//Pull breakpoints change
+export function pullBreakpoints():void {
+    Debugger.pullBreakpoints();
+}
+
 //Load and debug the specified file
 export function runFile(filePath: unknown, breakImmediately?: boolean, arg?: unknown[]): LuaMultiReturn<unknown[]> {
     if (typeof filePath !== "string") {

--- a/debugger/lldebugger.ts
+++ b/debugger/lldebugger.ts
@@ -56,7 +56,7 @@ export function stop(): void {
 }
 
 //Pull breakpoints change
-export function pullBreakpoints():void {
+export function pullBreakpoints(): void {
     Debugger.pullBreakpoints();
 }
 

--- a/debugger/protocol.d.ts
+++ b/debugger/protocol.d.ts
@@ -119,4 +119,5 @@ declare namespace LuaDebug {
     type StepUnmappedLinesEnv = "LOCAL_LUA_DEBUGGER_STEP_UNMAPPED_LINES";
     type InputFileEnv = "LOCAL_LUA_DEBUGGER_INPUT_FILE";
     type OutputFileEnv = "LOCAL_LUA_DEBUGGER_OUTPUT_FILE";
+    type PullFileEnv = "LOCAL_LUA_DEBUGGER_PULL_FILE";
 }

--- a/extension/launchConfig.ts
+++ b/extension/launchConfig.ts
@@ -42,6 +42,7 @@ export interface LaunchConfig {
     verbose?: boolean;
     stopOnEntry?: boolean;
     breakInCoroutines?: boolean;
+    pullBreakpointsSupport?: boolean;
     stepUnmappedLines?: boolean;
     scriptFiles?: string[];
     ignorePatterns?: string[];

--- a/extension/luaDebugSession.ts
+++ b/extension/luaDebugSession.ts
@@ -852,6 +852,7 @@ export class LuaDebugSession extends LoggingDebugSession {
 
     private async onDebuggerStop(msg: LuaDebug.DebugBreak) {
         this.isRunning = false;
+        let prevInDebugger = this.inDebuggerBreakpoint;
         this.inDebuggerBreakpoint = true;
 
         if (this.pendingScripts) {
@@ -910,6 +911,7 @@ export class LuaDebugSession extends LoggingDebugSession {
 
         if (this.autoContinueNext) {
             this.autoContinueNext = false;
+            this.inDebuggerBreakpoint = prevInDebugger;
             this.assert(this.sendCommand("autocont"));
 
         } else {

--- a/extension/luaDebugSession.ts
+++ b/extension/luaDebugSession.ts
@@ -247,7 +247,7 @@ export class LuaDebugSession extends LoggingDebugSession {
             processOptions.env[stepUnmappedLinesEnv] = this.config.stepUnmappedLines ? "1" : "0";
         }
 
-        this.usePipeCommutication = this.config.program.communication === "pipe"
+        this.usePipeCommutication = this.config.program.communication === "pipe";
 
         //Open pipes
         if (this.usePipeCommutication || this.pullBreakpointsSupport) {
@@ -262,14 +262,14 @@ export class LuaDebugSession extends LoggingDebugSession {
                     data => { void this.onDebuggerOutput(data); },
                     err => { this.showOutput(`${err}`, OutputCategory.Error); }
                 );
-    
+
                 processOptions.env[outputFileEnv] = this.debugPipe.getOutputPipePath();
                 processOptions.env[inputFileEnv] = this.debugPipe.getInputPipePath();
             }
         }
 
         if (this.pullBreakpointsSupport) {
-            this.debugPipe?.openPull(err => { this.showOutput(`${err}`, OutputCategory.Error); })
+            this.debugPipe?.openPull(err => { this.showOutput(`${err}`, OutputCategory.Error); });
             processOptions.env[pullFileEnv] = this.debugPipe?.getPullPipePath();
         }
 
@@ -346,7 +346,7 @@ export class LuaDebugSession extends LoggingDebugSession {
                 this.autoContinueNext = true;
                 this.debugPipe?.requestPull();
             }
-            
+
             const oldBreakpoints = this.fileBreakpoints[filePath];
             if (typeof oldBreakpoints !== "undefined") {
                 for (const breakpoint of oldBreakpoints) {
@@ -852,7 +852,7 @@ export class LuaDebugSession extends LoggingDebugSession {
 
     private async onDebuggerStop(msg: LuaDebug.DebugBreak) {
         this.isRunning = false;
-        let prevInDebugger = this.inDebuggerBreakpoint;
+        const prevInDebugger = this.inDebuggerBreakpoint;
         this.inDebuggerBreakpoint = true;
 
         if (this.pendingScripts) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "local-lua-debugger-vscode",
-    "version": "0.3.1",
+    "version": "0.3.3",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "local-lua-debugger-vscode",
-            "version": "0.3.1",
+            "version": "0.3.3",
             "license": "MIT",
             "dependencies": {
                 "vscode-debugadapter": "^1.48.0"

--- a/package.json
+++ b/package.json
@@ -117,6 +117,11 @@
                                 "description": "Break on errors inside of coroutines",
                                 "default": true
                             },
+                            "pullBreakpointsSupport": {
+                                "type": "boolean",
+                                "description": "Runtime supports pulling of breakpoints. (need to periodically call lldebugger.pullBreakpoints())",
+                                "default": true
+                            },
                             "scriptFiles": {
                                 "type": "array",
                                 "items": {

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
                             "pullBreakpointsSupport": {
                                 "type": "boolean",
                                 "description": "Runtime supports pulling of breakpoints. (need to periodically call lldebugger.pullBreakpoints())",
-                                "default": true
+                                "default": false
                             },
                             "scriptFiles": {
                                 "type": "array",


### PR DESCRIPTION
breakpoints pulling for debugger.

Settings now has parameter `pullBreakpointsSupport` (false by default) which responds to update breakpoints. Is you application is running and you change breakpoints configuration - this changes will be synchronized immediately after client call `lldebugger.pullBreakpoints()`. 

It's recommended to call `lldebugger.pullBreakpoints()` every update. It should be cheap as it only makes `seek("end")` for synchronization file
